### PR TITLE
Nuex start scripts

### DIFF
--- a/priv/templates/bin.dtl
+++ b/priv/templates/bin.dtl
@@ -17,7 +17,8 @@ find_erts_dir() {
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
         local erl="$(which erl)"
-        local erl_root=$("$erl" -noshell -eval "io:format(\"~s\", [code:root_dir()])." -s init stop)
+        code="io:format(\"~s\", [code:root_dir()])."
+        local erl_root="$("$erl" -noshell -eval "$code" -s init stop)"
         ERTS_DIR="$erl_root/erts-$ERTS_VSN"
         ROOTDIR="$erl_root"
     fi

--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -19,7 +19,6 @@ find_erts_dir() {
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
         local erl="$(which erl)"
-        local erl_root=$("$erl" -noshell -eval "io:format(\"~s\", [code:root_dir()])." -s init stop)
         code="io:format(\"~s\", [code:root_dir()])."
         local erl_root="$("$erl" -noshell -eval "$code" -s init stop)"
         ERTS_DIR="$erl_root/erts-$ERTS_VSN"


### PR DESCRIPTION
I tested this on a directory with spaces and a directory without spaces and I was able to start my app.

I did notice some other problems:
- running the command without options attempts to start an erlang shell for some reason
- running `app console` echos the path on a line after the `Exec`
- remsh function assumes you're executing it from the release directory (doesn't use ERTS_DIR)
